### PR TITLE
fix: clamp negative reltuples to 0 for table record count

### DIFF
--- a/db/table_ops.py
+++ b/db/table_ops.py
@@ -67,9 +67,10 @@ def get_table_details(credentials, db_name, table_name):
         cur.execute(query, (table_name,))
         row = cur.fetchone()
         if row:
+            estimated_rows = row[1]
             details = {
                 "Table Name": row[0],
-                "Record Count": row[1]
+                "Record Count": max(estimated_rows, 0)
             }
             return details
         else:


### PR DESCRIPTION
pg_class.reltuples returns -1 when a table has never been analyzed (no ANALYZE/VACUUM since creation or truncation). This caused the UI to display "Record Count: -1". Now clamps to 0 as a floor.

https://claude.ai/code/session_01Y8qjPsPjUWmPyraDBbtNir